### PR TITLE
cargo: thread default hidapi backend feature

### DIFF
--- a/co2mon/Cargo.toml
+++ b/co2mon/Cargo.toml
@@ -12,11 +12,12 @@ repository = "https://github.com/lnicola/co2mon"
 exclude = ["udev/*"]
 
 [features]
+default = ["linux-static-libusb"]
 linux-static-libusb = ["hidapi/linux-static-libusb"]
 linux-static-hidraw = ["hidapi/linux-static-hidraw"]
 linux-shared-libusb = ["hidapi/linux-shared-libusb"]
 linux-shared-hidraw = ["hidapi/linux-shared-hidraw"]
 
 [dependencies]
-hidapi = "1.0"
+hidapi = { version = "1.0", default-features = false }
 zg-co2 = { version = "2.0", path = "../zg-co2" }


### PR DESCRIPTION
Currently, enabling one of the other `hidapi` backends with a feature:
```toml
co2mon = { version = "2.0.2", features = ["linux-shared-libusb"] }
```
 results in a compile error:

```log
error: failed to run custom build command for `hidapi v1.1.0`

Caused by:
  process didn't exit successfully: `/home/tom/Documents/personal/coot/target/debug/build/hidapi-6c72b125013cc9b2/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'Exactly one linux hidapi backend must be selected.', /home/tom/.cargo/registry/src/github.com-1ecc6299db9ec823/hidapi-1.1.0/build.rs:94:9
```

This is due to the fact that `hidapi` itself enables one of the backends as a default feature. To allow ergonomic backend selection, `co2mon` should also mirror the default features of `hidapi`, as it currently does the features. This allows:

```toml
co2mon = { version = "2.0.2", features = ["linux-shared-libusb"], default-features = false }
```

This changes is backwards compatible (unless someone is building `co2mon` with `--no-default-features`, when it doesn't have any features).
