### PR TITLE
fix: skip decryption for newer devices (e.g. coach, but also mini)

### DIFF
--- a/co2mon/src/lib.rs
+++ b/co2mon/src/lib.rs
@@ -4,9 +4,9 @@
 //! A driver for the Holtek ([ZyAura ZG][ZG]) CO₂ USB monitors.
 //!
 //! The implementation was tested using a
-//! [TFA-Dostmann AIRCO2TROL MINI][AIRCO2TROL MINI] sensor.
+//! [TFA-Dostmann AIRCO2NTROL MINI][AIRCO2NTROL MINI] sensor.
 //!
-//! [AIRCO2TROL MINI]: https://www.tfa-dostmann.de/en/produkt/co2-monitor-airco2ntrol-mini/
+//! [AIRCO2NTROL MINI]: https://www.tfa-dostmann.de/en/produkt/co2-monitor-airco2ntrol-mini/
 //! [ZG]: http://www.zyaura.com/products/ZG_module.asp
 //!
 //! # Example usage
@@ -224,7 +224,13 @@ impl Sensor {
             return Err(Error::InvalidMessage);
         }
 
-        let data = decrypt(data, self.key);
+        // if the "magic byte" is present no decryption is necessary. This is the case for AirCO2ntrol Coach
+        // and "newer" AirCO2ntrol minis in general
+        let data = if data[4] == 0x0d {
+            data
+        } else {
+            decrypt(data, self.key)
+        };
         let reading = zg_co2::decode([data[0], data[1], data[2], data[3], data[4]])?;
         Ok(reading)
     }


### PR DESCRIPTION
Hey, I just got a AirCO2ntrol mini a couple of days ago.
It did not work with the `watch` example, I always got the "invalid message" error.

I checked the [nodejs implementation](https://github.com/huhamhire/node-co2-monitor) and it worked, so I looked deeper into the code, and it looks as if newer Aircontrol minis (and given the comment in the node project also the "coach" model) do not do the pseudo-encryption stuff.
I did not find any documentation/reference besides https://github.com/huhamhire/node-co2-monitor/commit/21458d4eb90dca3bb90c0d5269b39eace2f0df4e.

I implemented the same logic (skipping decryption if the "magic byte" is already present) and now reading the sensor values simply works (and of course matches the values shown on the display).