### PR TITLE
Fix co2mon documentation formating

### DIFF
--- a/co2mon/src/lib.rs
+++ b/co2mon/src/lib.rs
@@ -35,8 +35,8 @@
 //! Then reload the rules and trigger them:
 //!
 //! ```text
-//! # udevadm control --reload
-//! # udevadm trigger
+//! udevadm control --reload
+//! udevadm trigger
 //! ```
 //!
 //! Note that the `udev` rule above makes the device accessible to every local user.

--- a/co2mon/src/lib.rs
+++ b/co2mon/src/lib.rs
@@ -35,8 +35,8 @@
 //! Then reload the rules and trigger them:
 //!
 //! ```text
-//! udevadm control --reload
-//! udevadm trigger
+//! ## udevadm control --reload
+//! ## udevadm trigger
 //! ```
 //!
 //! Note that the `udev` rule above makes the device accessible to every local user.


### PR DESCRIPTION
Otherwise `cargo doc` will hide the commands:
![image](https://user-images.githubusercontent.com/905857/135718108-c6e2fc6c-74c7-406f-8327-1b86cd4d0795.png)
